### PR TITLE
(Improvement) Switch deploy icons to standard emojis overridable via env vars

### DIFF
--- a/slack-message/build_message.py
+++ b/slack-message/build_message.py
@@ -6,13 +6,16 @@ import requests
 import sys
 
 DEPLOY_STATUS = os.environ.get("DEPLOY_STATUS", "pending")
-DEPLOY_STATUS_ICONS = dict(failure=":cross:", pending=":buffering:")
 GITHUB_ACTOR = os.environ.get("GITHUB_ACTOR", "")
 GITHUB_ACTOR_URL = f"https://github.com/{GITHUB_ACTOR}"
 GITHUB_REPOSITORY = os.environ.get("GITHUB_REPOSITORY", "")
 GITHUB_REPOSITORY_URL = f"https://github.com/{GITHUB_REPOSITORY}"
 GITHUB_RUN_ID = os.environ.get("GITHUB_RUN_ID", "")
-GITHUB_RUN_STATUS_ICON = DEPLOY_STATUS_ICONS.get(DEPLOY_STATUS, "🚀")
+GITHUB_RUN_STATUS_ICON = dict(
+    failure=os.environ.get("RELEASE_BUILDER_DEPLOY_FAILURE_ICON", "❌"),
+    pending=os.environ.get("RELEASE_BUILDER_DEPLOY_PENDING_ICON", "⏳"),
+    success=os.environ.get("RELEASE_BUILDER_DEPLOY_SUCCESS_ICON", "🚀"),
+).get(DEPLOY_STATUS, os.environ.get("RELEASE_BUILDER_DEPLOY_ICON", "🚀"))
 GITHUB_RUN_URL = f"{GITHUB_REPOSITORY_URL}/actions/runs/{GITHUB_RUN_ID}"
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
 MESSAGE_TEMPLATE = os.environ.get("MESSAGE_TEMPLATE", "")


### PR DESCRIPTION
Slacks outside of Gun.io might not have sick custom emoji like `:buffering:` or `:cross:` so lets default to ❌ and ⏳ and supply rad ones via org vars.

Related #2